### PR TITLE
Make behavior of getStatesForPipelineId more consistent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>14.0</version>
+            <version>15.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.javascript</groupId>

--- a/src/main/java/org/arbeitspferde/groningen/historydatastore/MemoryHistoryDatastore.java
+++ b/src/main/java/org/arbeitspferde/groningen/historydatastore/MemoryHistoryDatastore.java
@@ -1,5 +1,6 @@
 package org.arbeitspferde.groningen.historydatastore;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.arbeitspferde.groningen.HistoryDatastore;
@@ -21,7 +22,7 @@ public class MemoryHistoryDatastore implements HistoryDatastore {
 
   private Map<PipelineId, List<PipelineHistoryState>> data =
       new HashMap<PipelineId, List<PipelineHistoryState>>();
-  
+
   @Override
   public void writeState(PipelineHistoryState state) {
     List<PipelineHistoryState> states = data.get(state.pipelineId());
@@ -43,8 +44,7 @@ public class MemoryHistoryDatastore implements HistoryDatastore {
     return Lists.newArrayList(data.keySet());
   }
 
-  @Override
-  public List<PipelineHistoryState> getStatesForPipelineId(PipelineId pipelineId) {
+  private List<PipelineHistoryState> readStates(PipelineId pipelineId) {
     List<PipelineHistoryState> states = data.get(pipelineId);
     if (states == null) {
       states = new ArrayList<PipelineHistoryState>();
@@ -53,17 +53,19 @@ public class MemoryHistoryDatastore implements HistoryDatastore {
   }
 
   @Override
+  public List<PipelineHistoryState> getStatesForPipelineId(PipelineId pipelineId) {
+    return ImmutableList.copyOf(readStates(pipelineId));
+  }
+
+  @Override
   public List<PipelineHistoryState> getStatesForPipelineId(
       PipelineId pipelineId, Instant afterTimestamp) {
-    List<PipelineHistoryState> states = data.get(pipelineId);
     List<PipelineHistoryState> results = new ArrayList<PipelineHistoryState>();
-    if (states != null) {
-      for (PipelineHistoryState s : states) {
-        if (s.endTimestamp().isAfter(afterTimestamp)) {
-          results.add(s);
-        }
+    for (PipelineHistoryState state : readStates(pipelineId)) {
+      if (state.endTimestamp().isAfter(afterTimestamp)) {
+        results.add(state);
       }
     }
-    return results;
+    return ImmutableList.copyOf(results);
   }
 }

--- a/src/main/java/org/arbeitspferde/groningen/historydatastore/MemoryHistoryDatastore.java
+++ b/src/main/java/org/arbeitspferde/groningen/historydatastore/MemoryHistoryDatastore.java
@@ -21,7 +21,7 @@ public class MemoryHistoryDatastore implements HistoryDatastore {
 
   private Map<PipelineId, List<PipelineHistoryState>> data =
       new HashMap<PipelineId, List<PipelineHistoryState>>();
-  
+
   @Override
   public void writeState(PipelineHistoryState state) {
     List<PipelineHistoryState> states = data.get(state.pipelineId());
@@ -43,8 +43,7 @@ public class MemoryHistoryDatastore implements HistoryDatastore {
     return Lists.newArrayList(data.keySet());
   }
 
-  @Override
-  public List<PipelineHistoryState> getStatesForPipelineId(PipelineId pipelineId) {
+  private List<PipelineHistoryState> readStates(PipelineId pipelineId) {
     List<PipelineHistoryState> states = data.get(pipelineId);
     if (states == null) {
       states = new ArrayList<PipelineHistoryState>();
@@ -53,17 +52,19 @@ public class MemoryHistoryDatastore implements HistoryDatastore {
   }
 
   @Override
+  public List<PipelineHistoryState> getStatesForPipelineId(PipelineId pipelineId) {
+    return Collections.unmodifiableList(readStates(pipelineId));
+  }
+
+  @Override
   public List<PipelineHistoryState> getStatesForPipelineId(
       PipelineId pipelineId, Instant afterTimestamp) {
-    List<PipelineHistoryState> states = data.get(pipelineId);
     List<PipelineHistoryState> results = new ArrayList<PipelineHistoryState>();
-    if (states != null) {
-      for (PipelineHistoryState s : states) {
-        if (s.endTimestamp().isAfter(afterTimestamp)) {
-          results.add(s);
-        }
+    for (PipelineHistoryState state : readStates(pipelineId)) {
+      if (state.endTimestamp().isAfter(afterTimestamp)) {
+        results.add(state);
       }
     }
-    return results;
+    return Collections.unmodifiableList(results);
   }
 }


### PR DESCRIPTION
It now returns an unmodifiable list. Earlier, if the state existed, it
would pass a direct reference to the list which could be modified by
the callee. If not, it would create an empty state list but not store
its reference in the data map.
