### PR TITLE
unit designation can be omitted on the heap size parameters. Remove from...

### DIFF
--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/CommandLine.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/CommandLine.java
@@ -82,8 +82,8 @@ public class CommandLine {
       .add(JvmFlag.USE_PARALLEL_GC.asRegularExpressionString())
       .add(JvmFlag.USE_PARALLEL_OLD_GC.asRegularExpressionString())
       .add(JvmFlag.USE_SERIAL_GC.asRegularExpressionString())
-      .add("-Xms\\d+[bBkKmMgG]")
-      .add("-Xmx\\d+[bBkKmMgG]")
+      .add("-Xms\\d+[bBkKmMgG]?")
+      .add("-Xmx\\d+[bBkKmMgG]?")
       .build();
 
   /**


### PR DESCRIPTION
Unit designation can be omitted on the heap size parameters. Remove from the regex.
