### PR TITLE
Forward-port the Maven definition to use JDK 1.7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,8 +244,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
As of 59aaced678, the Process class migrated to using Java Native I/O
StandardCharsets.  This unfortunately broke compatibility with JRE 6.0,
since this class is only available in JRE 7.0 and onward.  Thusly update
Maven model to reflect this.
