### PR TITLE
Fix command line test

### DIFF
--- a/src/test/java/org/arbeitspferde/groningen/experimentdb/CommandLineTest.java
+++ b/src/test/java/org/arbeitspferde/groningen/experimentdb/CommandLineTest.java
@@ -209,7 +209,7 @@ public class CommandLineTest extends TestCase {
   }
 
   public void testRegularExpressionsMatch_ms() {
-    assertMatchesNever("-Xms1");
+    assertMatchesOnce("-Xms1");
 
     assertMatchesOnce("-Xms1k");
     assertMatchesOnce("-Xms1m");
@@ -226,7 +226,7 @@ public class CommandLineTest extends TestCase {
   }
 
   public void testRegularExpressionsMatch_mx() {
-    assertMatchesNever("-Xmx1");
+    assertMatchesOnce("-Xmx1");
 
     assertMatchesOnce("-Xmx1k");
     assertMatchesOnce("-Xmx1m");


### PR DESCRIPTION
`testRegularExpressionsMatch_ms` and `testRegularExpressionsMatch_mx` failed because regular expressions that manage `-Xms` and `-Xmx` flags respectively were updated, while the tests were not (see [L85-86](https://github.com/sladeware/groningen/blob/master/src/main/java/org/arbeitspferde/groningen/experimentdb/CommandLine.java#L85)).
