### PR TITLE
Explicitly name garbage collection strategies.

### DIFF
--- a/src/main/java/org/arbeitspferde/groningen/hypothesizer/Hypothesizer.java
+++ b/src/main/java/org/arbeitspferde/groningen/hypothesizer/Hypothesizer.java
@@ -371,7 +371,7 @@ public class Hypothesizer extends ProfilingRunnable {
           builder.withValue(JvmFlag.USE_PARALLEL_GC, 1L);
           break;
         case USE_PARALLEL_OLD_GC:
-          builder.withValue(JvmFlag.USE_PARALLEL_GC, 1L);
+          builder.withValue(JvmFlag.USE_PARALLEL_OLD_GC, 1L);
           break;
         case USE_SERIAL_GC:
           builder.withValue(JvmFlag.USE_SERIAL_GC, 1L);


### PR DESCRIPTION
Fix switch statement to allow `-XX:+UseParallelOldGC` to be specified.
