### PR TITLE
Prepare Flags for Overhaul

### DIFF
--- a/src/main/java/org/arbeitspferde/groningen/common/SettingsProvider.java
+++ b/src/main/java/org/arbeitspferde/groningen/common/SettingsProvider.java
@@ -120,7 +120,7 @@ public class SettingsProvider implements Provider<Settings> {
 
   @Override
   public Settings get() {
-    log.info("Providing settings.");
+    log.finest("Providing settings.");
 
     final Collection<Field> annotated = findAnnotatedFields();
     final Collection<String> args4jWhitelist = makeArgs4jWhitelist(annotated);

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/CommandLine.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/CommandLine.java
@@ -56,34 +56,33 @@ public class CommandLine {
   // //depot/vendor_src/java/jdk/hotspot/src/share/vm/runtime/globals.hpp
   // boolean flags have the form -XX:[+-]<flag>
   private static final ImmutableList<String> MANAGED_ARGS_REGEXES = ImmutableList.<String>builder()
-      .add(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR.asRegularExpressionString())
-      .add(JvmFlag.CMS_EXP_AVG_FACTOR.asRegularExpressionString())
-      .add(JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE.asRegularExpressionString())
-      .add(JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE_MIN.asRegularExpressionString())
-      .add(JvmFlag.CMS_INCREMENTAL_OFFSET.asRegularExpressionString())
-      .add(JvmFlag.CMS_INCREMENTAL_SAFETY_FACTOR.asRegularExpressionString())
-      .add(JvmFlag.CMS_INITIATING_OCCUPANCY_FRACTION.asRegularExpressionString())
-      .add(JvmFlag.GC_TIME_RATIO.asRegularExpressionString())
-      .add(JvmFlag.MAX_GC_PAUSE_MILLIS.asRegularExpressionString())
-      .add(JvmFlag.MAX_HEAP_FREE_RATIO.asRegularExpressionString())
-      .add(JvmFlag.MAX_NEW_SIZE.asRegularExpressionString())
-      .add(JvmFlag.MIN_HEAP_FREE_RATIO.asRegularExpressionString())
-      .add(JvmFlag.NEW_RATIO.asRegularExpressionString())
-      .add(JvmFlag.NEW_SIZE.asRegularExpressionString())
-      .add(JvmFlag.PARALLEL_GC_THREADS.asRegularExpressionString())
-      .add(JvmFlag.SOFT_REF_LRU_POLICY_MS_PER_MB.asRegularExpressionString())
-      .add(JvmFlag.SURVIVOR_RATIO.asRegularExpressionString())
-      .add(JvmFlag.TENURED_GENERATION_SIZE_INCREMENT.asRegularExpressionString())
-      .add(JvmFlag.YOUNG_GENERATION_SIZE_INCREMENT.asRegularExpressionString())
-      .add(JvmFlag.CMS_INCREMENTAL_MODE.asRegularExpressionString())
-      .add(JvmFlag.CMS_INCREMENTAL_PACING.asRegularExpressionString())
-      .add(JvmFlag.USE_CMS_INITIATING_OCCUPANCY_ONLY.asRegularExpressionString())
-      .add(JvmFlag.USE_CONC_MARK_SWEEP_GC.asRegularExpressionString())
-      .add(JvmFlag.USE_PARALLEL_GC.asRegularExpressionString())
-      .add(JvmFlag.USE_PARALLEL_OLD_GC.asRegularExpressionString())
-      .add(JvmFlag.USE_SERIAL_GC.asRegularExpressionString())
-      .add("-Xms\\d+[bBkKmMgG]?")
-      .add("-Xmx\\d+[bBkKmMgG]?")
+      .addAll(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR.asRegularExpressionString())
+      .addAll(JvmFlag.CMS_EXP_AVG_FACTOR.asRegularExpressionString())
+      .addAll(JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE.asRegularExpressionString())
+      .addAll(JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE_MIN.asRegularExpressionString())
+      .addAll(JvmFlag.CMS_INCREMENTAL_OFFSET.asRegularExpressionString())
+      .addAll(JvmFlag.CMS_INCREMENTAL_SAFETY_FACTOR.asRegularExpressionString())
+      .addAll(JvmFlag.CMS_INITIATING_OCCUPANCY_FRACTION.asRegularExpressionString())
+      .addAll(JvmFlag.GC_TIME_RATIO.asRegularExpressionString())
+      .addAll(JvmFlag.MAX_GC_PAUSE_MILLIS.asRegularExpressionString())
+      .addAll(JvmFlag.MAX_HEAP_FREE_RATIO.asRegularExpressionString())
+      .addAll(JvmFlag.MAX_NEW_SIZE.asRegularExpressionString())
+      .addAll(JvmFlag.MIN_HEAP_FREE_RATIO.asRegularExpressionString())
+      .addAll(JvmFlag.NEW_RATIO.asRegularExpressionString())
+      .addAll(JvmFlag.NEW_SIZE.asRegularExpressionString())
+      .addAll(JvmFlag.PARALLEL_GC_THREADS.asRegularExpressionString())
+      .addAll(JvmFlag.SOFT_REF_LRU_POLICY_MS_PER_MB.asRegularExpressionString())
+      .addAll(JvmFlag.SURVIVOR_RATIO.asRegularExpressionString())
+      .addAll(JvmFlag.TENURED_GENERATION_SIZE_INCREMENT.asRegularExpressionString())
+      .addAll(JvmFlag.YOUNG_GENERATION_SIZE_INCREMENT.asRegularExpressionString())
+      .addAll(JvmFlag.CMS_INCREMENTAL_MODE.asRegularExpressionString())
+      .addAll(JvmFlag.CMS_INCREMENTAL_PACING.asRegularExpressionString())
+      .addAll(JvmFlag.USE_CMS_INITIATING_OCCUPANCY_ONLY.asRegularExpressionString())
+      .addAll(JvmFlag.USE_CONC_MARK_SWEEP_GC.asRegularExpressionString())
+      .addAll(JvmFlag.USE_PARALLEL_GC.asRegularExpressionString())
+      .addAll(JvmFlag.USE_PARALLEL_OLD_GC.asRegularExpressionString())
+      .addAll(JvmFlag.USE_SERIAL_GC.asRegularExpressionString())
+      .addAll(JvmFlag.HEAP_SIZE.asRegularExpressionString())
       .build();
 
   /**
@@ -271,12 +270,12 @@ public class CommandLine {
     if (getMinHeapFreeRatio() <= getMaxHeapFreeRatio()) {
       if (getMinHeapFreeRatio() > 0) {
         JvmFlag.MIN_HEAP_FREE_RATIO.validate(getMinHeapFreeRatio());
-        argumentsBuilder.add(JvmFlag.MIN_HEAP_FREE_RATIO
+        argumentsBuilder.addAll(JvmFlag.MIN_HEAP_FREE_RATIO
             .asArgumentString(getMinHeapFreeRatio()));
       }
       if (getMaxHeapFreeRatio() > 0) {
         JvmFlag.MAX_HEAP_FREE_RATIO.validate(getMaxHeapFreeRatio());
-        argumentsBuilder.add(JvmFlag.MAX_HEAP_FREE_RATIO
+        argumentsBuilder.addAll(JvmFlag.MAX_HEAP_FREE_RATIO
             .asArgumentString(getMaxHeapFreeRatio()));
       }
     }
@@ -296,8 +295,7 @@ public class CommandLine {
     // generation) can grow to the limit of the virtual space as needed.
     if (getHeapSize() > 0) {
       JvmFlag.HEAP_SIZE.validate(getHeapSize());
-      argumentsBuilder.add(String.format("-Xmx%sm", getHeapSize()));
-      argumentsBuilder.add(String.format("-Xms%sm", getHeapSize()));
+      argumentsBuilder.addAll(JvmFlag.HEAP_SIZE.asArgumentString(getHeapSize()));
     }
 
 
@@ -320,7 +318,7 @@ public class CommandLine {
     // We assume that setting newRatio to 0 means ignore the setting
     if (getNewRatio() > 0) {
       JvmFlag.NEW_RATIO.validate(getNewRatio());
-      argumentsBuilder.add(JvmFlag.NEW_RATIO.asArgumentString(getNewRatio()));
+      argumentsBuilder.addAll(JvmFlag.NEW_RATIO.asArgumentString(getNewRatio()));
     } else
 
     // An eden bigger than half the virtually committed size of the heap is counterproductive. The
@@ -341,11 +339,11 @@ public class CommandLine {
       // The size is assumed to be in MB
       if (getNewSize() > 0) {
         JvmFlag.NEW_SIZE.validate(getNewSize());
-        argumentsBuilder.add(JvmFlag.NEW_SIZE.asArgumentString(getNewSize()));
+        argumentsBuilder.addAll(JvmFlag.NEW_SIZE.asArgumentString(getNewSize()));
         // Notice we are setting MaxNewSize to NewSize as this is a common thing
         // to do
         JvmFlag.MAX_NEW_SIZE.validate(getNewSize());
-        argumentsBuilder.add(JvmFlag.MAX_NEW_SIZE.asArgumentString(getNewSize()));
+        argumentsBuilder.addAll(JvmFlag.MAX_NEW_SIZE.asArgumentString(getNewSize()));
       }
     }
 
@@ -354,7 +352,7 @@ public class CommandLine {
     // this setting.
     if (getSurvivorRatio() > 0) {
       JvmFlag.SURVIVOR_RATIO.validate(getSurvivorRatio());
-      argumentsBuilder.add(JvmFlag.SURVIVOR_RATIO.asArgumentString(getSurvivorRatio()));
+      argumentsBuilder.addAll(JvmFlag.SURVIVOR_RATIO.asArgumentString(getSurvivorRatio()));
     }
 
     // Soft references are cleared less aggressively in the server virtual machine than the client.
@@ -366,7 +364,7 @@ public class CommandLine {
     // for 1 second for each megabyte of free space in the heap. This is very approximate.
     if (getSoftRefLruPolicyMsPerMb() > 0) {
       JvmFlag.SOFT_REF_LRU_POLICY_MS_PER_MB.validate(getSoftRefLruPolicyMsPerMb());
-      argumentsBuilder.add(JvmFlag.SOFT_REF_LRU_POLICY_MS_PER_MB
+      argumentsBuilder.addAll(JvmFlag.SOFT_REF_LRU_POLICY_MS_PER_MB
           .asArgumentString(getSoftRefLruPolicyMsPerMb()));
     }
 
@@ -379,7 +377,7 @@ public class CommandLine {
       // collector when the application is running. Typically applications which have a relatively
       // large set of long-lived data (a large tenured generation), and run on machines with two
       // or more processors tend to benefit from the use of this collector.
-      argumentsBuilder.add(JvmFlag.USE_CONC_MARK_SWEEP_GC.asArgumentString(TRUE_AS_LONG));
+      argumentsBuilder.addAll(JvmFlag.USE_CONC_MARK_SWEEP_GC.asArgumentString(TRUE_AS_LONG));
 
       // Normally, the concurrent collector uses one processor for the concurrent work for the
       // entire concurrent mark phase, without (voluntarily) relinquishing it.  Similarly, one
@@ -395,12 +393,12 @@ public class CommandLine {
       // can automatically compute the duty cycle based on the behavior of the application (the
       // recommended method), or the duty cycle can be set to a fixed value on the command line.
       if (getCmsIncrementalMode()) {
-        argumentsBuilder.add(JvmFlag.CMS_INCREMENTAL_MODE.asArgumentString(TRUE_AS_LONG));
+        argumentsBuilder.addAll(JvmFlag.CMS_INCREMENTAL_MODE.asArgumentString(TRUE_AS_LONG));
 
         // This flag enables automatic adjustment of the incremental mode duty cycle based on
         // statistics collected while the JVM is running.
         if (getCmsIncrementalPacing()) {
-          argumentsBuilder.add(JvmFlag.CMS_INCREMENTAL_PACING.asArgumentString(TRUE_AS_LONG));
+          argumentsBuilder.addAll(JvmFlag.CMS_INCREMENTAL_PACING.asArgumentString(TRUE_AS_LONG));
           // This is the percentage (0-100) which is the lower bound on the duty
           // cycle when
           // CMSIncrementalPacing is enabled.
@@ -408,7 +406,7 @@ public class CommandLine {
           // We assume that setting this to 0 means ignore the setting
           if (getCmsIncrementalDutyCycleMin() > 0) {
             JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE_MIN.validate(getCmsIncrementalDutyCycle());
-            argumentsBuilder.add(JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE_MIN
+            argumentsBuilder.addAll(JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE_MIN
                 .asArgumentString(getCmsIncrementalDutyCycleMin()));
           }
         }
@@ -419,7 +417,7 @@ public class CommandLine {
         // We assume that setting this to 0 means ignore the setting
         if (getCmsExpAvgFactor() > 0) {
           JvmFlag.CMS_EXP_AVG_FACTOR.validate(getCmsExpAvgFactor());
-          argumentsBuilder.add(JvmFlag.CMS_EXP_AVG_FACTOR
+          argumentsBuilder.addAll(JvmFlag.CMS_EXP_AVG_FACTOR
               .asArgumentString(getCmsExpAvgFactor()));
         }
 
@@ -430,7 +428,7 @@ public class CommandLine {
         // We assume that setting this to 0 means ignore the setting
         if (getCmsIncrementalDutyCycle() > 0) {
           JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE.validate(getCmsIncrementalDutyCycle());
-          argumentsBuilder.add(JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE
+          argumentsBuilder.addAll(JvmFlag.CMS_INCREMENTAL_DUTY_CYCLE
               .asArgumentString(getCmsIncrementalDutyCycle()));
         }
 
@@ -440,14 +438,14 @@ public class CommandLine {
         // We assume that setting this to 0 means ignore the setting
         if (getCmsIncrementalOffset() > 0) {
           JvmFlag.CMS_INCREMENTAL_OFFSET.validate(getCmsIncrementalOffset());
-          argumentsBuilder.add(JvmFlag.CMS_INCREMENTAL_OFFSET
+          argumentsBuilder.addAll(JvmFlag.CMS_INCREMENTAL_OFFSET
               .asArgumentString(getCmsIncrementalOffset()));
         }
 
         // This is the percentage (0-100) used to add conservatism when computing the duty cycle.
         if (getCmsIncrementalSafetyFactor() > 0) {
           JvmFlag.CMS_INCREMENTAL_SAFETY_FACTOR.validate(getCmsIncrementalSafetyFactor());
-          argumentsBuilder.add(JvmFlag.CMS_INCREMENTAL_SAFETY_FACTOR
+          argumentsBuilder.addAll(JvmFlag.CMS_INCREMENTAL_SAFETY_FACTOR
               .asArgumentString(getCmsIncrementalSafetyFactor()));
         }
       }
@@ -457,14 +455,14 @@ public class CommandLine {
       // GC in the tenured generation.
       if (getCmsInitiatingOccupancyFraction() > 0) {
         JvmFlag.CMS_INITIATING_OCCUPANCY_FRACTION.validate(getCmsInitiatingOccupancyFraction());
-        argumentsBuilder.add(JvmFlag.CMS_INITIATING_OCCUPANCY_FRACTION
+        argumentsBuilder.addAll(JvmFlag.CMS_INITIATING_OCCUPANCY_FRACTION
             .asArgumentString((getCmsInitiatingOccupancyFraction())));
         // This parameter tells the JVM to use only the value defined by
         // -XX:CMSInitiatingOccupancyFraction, rather than try to also calculate
         // the value at
         // runtime.
 
-        argumentsBuilder.add(JvmFlag.USE_CMS_INITIATING_OCCUPANCY_ONLY
+        argumentsBuilder.addAll(JvmFlag.USE_CMS_INITIATING_OCCUPANCY_ONLY
             .asArgumentString(getUseCmsInitiatingOccupancyOnly() ? TRUE_AS_LONG : FALSE_AS_LONG));
       }
     } else if (getUseParallelGC() || getUseParallelOldGC()) {
@@ -482,12 +480,12 @@ public class CommandLine {
       // than 2 CPUs.
 
       // Young Generation GC done in parallel threads
-      argumentsBuilder.add(JvmFlag.USE_PARALLEL_GC.asArgumentString(
+      argumentsBuilder.addAll(JvmFlag.USE_PARALLEL_GC.asArgumentString(
           getUseParallelGC() ? TRUE_AS_LONG : FALSE_AS_LONG));
 
       // Certain phases of an ‘Old Generation’ collection can be performed in parallel, speeding
       // up a old generation collection.
-      argumentsBuilder.add(JvmFlag.USE_PARALLEL_OLD_GC.asArgumentString(getUseParallelOldGC()
+      argumentsBuilder.addAll(JvmFlag.USE_PARALLEL_OLD_GC.asArgumentString(getUseParallelOldGC()
           ? TRUE_AS_LONG : FALSE_AS_LONG));
 
       // Growing and shrinking the size of a generation is done by increments that are a fixed
@@ -500,12 +498,12 @@ public class CommandLine {
       // We assume 0 means ignore the setting.
       if (getYoungGenerationSizeIncrement() > 0) {
         JvmFlag.YOUNG_GENERATION_SIZE_INCREMENT.validate(getYoungGenerationSizeIncrement());
-        argumentsBuilder.add(JvmFlag.YOUNG_GENERATION_SIZE_INCREMENT
+        argumentsBuilder.addAll(JvmFlag.YOUNG_GENERATION_SIZE_INCREMENT
             .asArgumentString(getYoungGenerationSizeIncrement()));
       }
       if (getTenuredGenerationSizeIncrement() > 0) {
         JvmFlag.TENURED_GENERATION_SIZE_INCREMENT.validate(getTenuredGenerationSizeIncrement());
-        argumentsBuilder.add(JvmFlag.TENURED_GENERATION_SIZE_INCREMENT
+        argumentsBuilder.addAll(JvmFlag.TENURED_GENERATION_SIZE_INCREMENT
             .asArgumentString(getTenuredGenerationSizeIncrement()));
       }
 
@@ -517,7 +515,7 @@ public class CommandLine {
       if (getAdaptiveSizeDecrementScaleFactor() > 0) {
         JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR
             .validate(getAdaptiveSizeDecrementScaleFactor());
-        argumentsBuilder.add(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR
+        argumentsBuilder.addAll(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR
             .asArgumentString(getAdaptiveSizeDecrementScaleFactor()));
       }
 
@@ -527,7 +525,7 @@ public class CommandLine {
       // We assume that setting this to 0 means ignore the setting
       if (getGcTimeRatio() > 0) {
         JvmFlag.GC_TIME_RATIO.validate(getGcTimeRatio());
-        argumentsBuilder.add(JvmFlag.GC_TIME_RATIO.asArgumentString(getGcTimeRatio()));
+        argumentsBuilder.addAll(JvmFlag.GC_TIME_RATIO.asArgumentString(getGcTimeRatio()));
       }
 
       // This is interpreted as a hint to the throughput collector that pause times of <nnn>
@@ -540,7 +538,7 @@ public class CommandLine {
       // We assume that setting this to 0 means ignore the setting
       if (getMaxHeapFreeRatio() > 0) {
         JvmFlag.MAX_GC_PAUSE_MILLIS.validate(getMaxGcPauseMillis());
-        argumentsBuilder.add(JvmFlag.MAX_GC_PAUSE_MILLIS
+        argumentsBuilder.addAll(JvmFlag.MAX_GC_PAUSE_MILLIS
             .asArgumentString(getMaxGcPauseMillis()));
       }
 
@@ -548,7 +546,7 @@ public class CommandLine {
       // command line option. We assume 0 implies do not set this parameter.
       if (getParallelGCThreads() > 0) {
         JvmFlag.PARALLEL_GC_THREADS.validate(getParallelGCThreads());
-        argumentsBuilder.add(JvmFlag.PARALLEL_GC_THREADS
+        argumentsBuilder.addAll(JvmFlag.PARALLEL_GC_THREADS
             .asArgumentString(getParallelGCThreads()));
       }
     } else if (getUseSerialGC()) {
@@ -559,7 +557,7 @@ public class CommandLine {
       // inversely proportional to the size of the heap.
       //
       // It is the best choice for a single CPU and a small heap.
-      argumentsBuilder.add(JvmFlag.USE_SERIAL_GC.asArgumentString(TRUE_AS_LONG));
+      argumentsBuilder.addAll(JvmFlag.USE_SERIAL_GC.asArgumentString(TRUE_AS_LONG));
     }
 
     final String emission = spaceSeparator.join(argumentsBuilder.build());

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/ExperimentDb.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/ExperimentDb.java
@@ -77,7 +77,7 @@ public class ExperimentDb {
     final StringBuilder output = new StringBuilder();
     output.append("ExperimentDb ").append(methodName).append(" :");
     spaceSeparator.appendTo(output, values);
-    log.info(output.toString());
+    log.finest(output.toString());
   }
 
   /** The logger is being made available so tests can add a handler */

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/DataSize.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/DataSize.java
@@ -29,11 +29,6 @@ enum DataSize {
   NONE(""),
 
   /**
-   * The units are in bytes.
-   */
-  BYTE("b"),
-
-  /**
    * The units are in kilobytes.
    */
   KILO("k"),
@@ -94,7 +89,7 @@ enum DataSize {
     for (final DataSize dataSize : values()) {
       builder.append(dataSize.suffixToRegexpString());
     }
-    builder.append("]");
+    builder.append("]?");
 
     DATASIZE_SUFFIX_REGEXP = builder.toString();
   }

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Formatter.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Formatter.java
@@ -39,24 +39,4 @@ interface Formatter {
    * @return The regular expression representation.
    */
   String asRegularExpressionString(final JvmFlag cla);
-
-  /**
-   * Provide a representation of the acceptable values the flag may be set to.
-   *
-   * @param cla The argument for which this formatter is used.
-   * @return The valid value representation.
-   */
-  String asAcceptableValuesString(final JvmFlag cla);
-
-  /**
-   * Verify that the proposed value is acceptable.
-   *
-   * Implementors should include information in the thrown exception about why
-   * proposedValue is unacceptable.
-   *
-   * @param cla The argument for which this formatter is used.
-   * @param proposedValue The value to verify.
-   * @throws IllegalArgumentException if proposedValue is unacceptable.
-   */
-  void validate(final JvmFlag cla, final long proposedValue) throws IllegalArgumentException;
 }

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Formatter.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Formatter.java
@@ -15,6 +15,8 @@
 
 package org.arbeitspferde.groningen.experimentdb.jvmflags;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * Provide standardized representation and validation of flags.
  *
@@ -30,7 +32,7 @@ interface Formatter {
    * @param value The value that the flag shall be set to.
    * @return The emitted formatted argument string.
    */
-  String asArgumentString(final JvmFlag cla, final long value);
+  ImmutableList<String> asArgumentString(final JvmFlag cla, final long value);
 
   /**
    * Provide a representation of the flag with possible values as a reg. exp.
@@ -38,5 +40,5 @@ interface Formatter {
    * @param cla The argument for which this formatter is used.
    * @return The regular expression representation.
    */
-  String asRegularExpressionString(final JvmFlag cla);
+  ImmutableList<String> asRegularExpressionString(final JvmFlag cla);
 }

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Formatters.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Formatters.java
@@ -16,7 +16,6 @@
 package org.arbeitspferde.groningen.experimentdb.jvmflags;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Range;
 
 /**
  * A repository of {@link Formatter} implementations.
@@ -31,19 +30,12 @@ class Formatters {
   /**
    * Utility class; no instantiation allowed!
    */
-  private Formatters() {
-  }
+  private Formatters() {}
 
   /**
    * Provide a representation and validations for integer-based JVM Flags.
    */
-  static final Formatter INTEGER_FORMATTER = new Formatter() {
-    /**
-     * Validate that numeric values are in the acceptable range for {@link Integer}.
-     */
-    private final Range<Long> inherentAcceptableValues = Range.closed((long) Integer.MIN_VALUE,
-      (long) Integer.MAX_VALUE);
-
+  static final Formatter INTEGER = new Formatter() {
     @Override
     public String asArgumentString(final JvmFlag cla, final long value) {
       Preconditions.checkNotNull(cla, "cla may not be null.");
@@ -59,34 +51,13 @@ class Formatters {
       return String.format("%s%s%s\\d+%s\\b", cla.getHotSpotFlagType().getPrefix(), cla.getName(),
         cla.getValueSeparator().getInfix(), cla.getDataSize().unitFamilyAsRegexpString());
     }
-
-    @Override
-    public String asAcceptableValuesString(final JvmFlag cla) {
-      Preconditions.checkNotNull(cla, "cla may not be null.");
-
-      return cla.getAcceptableValueRange().toString();
-    }
-
-    @Override
-    public void validate(final JvmFlag cla, final long proposedValue)
-        throws IllegalArgumentException {
-      Preconditions.checkNotNull(cla, "cla may not be null.");
-      Preconditions.checkArgument(inherentAcceptableValues.contains(proposedValue));
-      Preconditions.checkArgument(
-          cla.getAcceptableValueRange().contains(proposedValue),
-          "The flag %s with range %s cannot contain proposed value %s.",
-          cla.getName(), cla.getAcceptableValueRange(),
-          proposedValue);
-    }
   };
 
   /**
    * Provide a representation and validations for boolean-based JVM Flags.
    */
-  static final Formatter BOOLEAN_FORMATTER = new Formatter() {
+  static final Formatter BOOLEAN = new Formatter() {
     private final long TRUE_AS_LONG = 1;
-
-    private final Range<Long> inherentAcceptableValues = Range.closed(0L, 1L);
 
     @Override
     public String asArgumentString(final JvmFlag cla,
@@ -105,20 +76,5 @@ class Formatters {
 
       return String.format("%s[+-]%s", cla.getHotSpotFlagType().getPrefix(), cla.getName());
     }
-
-    @Override
-    public String asAcceptableValuesString(final JvmFlag cla) {
-      Preconditions.checkNotNull(cla, "cla may not be null.");
-
-      return "{0 (false), 1 (true)}";
-    }
-
-    @Override
-    public void validate(final JvmFlag cla, final long proposedValue)
-        throws IllegalArgumentException {
-      Preconditions.checkNotNull(cla, "cla may not be null.");
-      Preconditions.checkArgument(inherentAcceptableValues.contains(proposedValue));
-    }
   };
-
 }

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Formatters.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Formatters.java
@@ -16,6 +16,7 @@
 package org.arbeitspferde.groningen.experimentdb.jvmflags;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 /**
  * A repository of {@link Formatter} implementations.
@@ -37,19 +38,21 @@ class Formatters {
    */
   static final Formatter INTEGER = new Formatter() {
     @Override
-    public String asArgumentString(final JvmFlag cla, final long value) {
+    public ImmutableList<String> asArgumentString(final JvmFlag cla, final long value) {
       Preconditions.checkNotNull(cla, "cla may not be null.");
+      Preconditions.checkState(cla.hasName(), "cla must have name");
 
-      return String.format("%s%s%s%s%s", cla.getHotSpotFlagType().getPrefix(), cla.getName(),
-          cla.getValueSeparator().getInfix(), value, cla.getDataSize().getSuffix());
+      return ImmutableList.of(String.format("%s%s%s%s%s", cla.getHotSpotFlagType().getPrefix(), cla.getName(),
+          cla.getValueSeparator().getInfix(), value, cla.getDataSize().getSuffix()));
     }
 
     @Override
-    public String asRegularExpressionString(final JvmFlag cla) {
+    public ImmutableList<String> asRegularExpressionString(final JvmFlag cla) {
       Preconditions.checkNotNull(cla, "cla may not be null.");
+      Preconditions.checkState(cla.hasName(), "cla must have name");
 
-      return String.format("%s%s%s\\d+%s\\b", cla.getHotSpotFlagType().getPrefix(), cla.getName(),
-        cla.getValueSeparator().getInfix(), cla.getDataSize().unitFamilyAsRegexpString());
+      return ImmutableList.of(String.format("%s%s%s\\d+%s\\b", cla.getHotSpotFlagType().getPrefix(), cla.getName(),
+        cla.getValueSeparator().getInfix(), cla.getDataSize().unitFamilyAsRegexpString()));
     }
   };
 
@@ -60,21 +63,45 @@ class Formatters {
     private final long TRUE_AS_LONG = 1;
 
     @Override
-    public String asArgumentString(final JvmFlag cla,
+    public ImmutableList<String> asArgumentString(final JvmFlag cla,
                                    final long value) {
       Preconditions.checkNotNull(cla, "cla may not be null.");
+      Preconditions.checkState(cla.hasName(), "cla must have name");
 
       final String plusOrMinus = value == TRUE_AS_LONG ? "+" : "-";
 
-      return String.format("%s%s%s", cla.getHotSpotFlagType().getPrefix(), plusOrMinus,
-        cla.getName());
+      return ImmutableList.of(String.format("%s%s%s", cla.getHotSpotFlagType().getPrefix(), plusOrMinus,
+          cla.getName()));
     }
 
     @Override
-    public String asRegularExpressionString(final JvmFlag cla) {
+    public ImmutableList<String> asRegularExpressionString(final JvmFlag cla) {
       Preconditions.checkNotNull(cla, "cla may not be null.");
+      Preconditions.checkState(cla.hasName(), "cla must have name");
 
-      return String.format("%s[+-]%s", cla.getHotSpotFlagType().getPrefix(), cla.getName());
+      return ImmutableList.of(String.format("%s[+-]%s", cla.getHotSpotFlagType().getPrefix(), cla.getName()));
     }
   };
+
+  static Formatter pinnedIntervalInteger(final String minimumName, final String maximumName) {
+    return new Formatter() {
+      @Override
+      public ImmutableList<String> asArgumentString(JvmFlag cla, long value) {
+        return ImmutableList.of(
+            String.format("%s%s%s%s%s", cla.getHotSpotFlagType().getPrefix(), minimumName,
+                cla.getValueSeparator().getInfix(), value, cla.getDataSize().getSuffix()),
+            String.format("%s%s%s%s%s", cla.getHotSpotFlagType().getPrefix(), maximumName,
+                cla.getValueSeparator().getInfix(), value, cla.getDataSize().getSuffix()));
+      }
+
+      @Override
+      public ImmutableList<String> asRegularExpressionString(JvmFlag cla) {
+        return ImmutableList.of(
+            String.format("%s%s%s\\d+%s\\b", cla.getHotSpotFlagType().getPrefix(), minimumName,
+                cla.getValueSeparator().getInfix(), cla.getDataSize().unitFamilyAsRegexpString()),
+            String.format("%s%s%s\\d+%s\\b", cla.getHotSpotFlagType().getPrefix(), maximumName,
+                cla.getValueSeparator().getInfix(), cla.getDataSize().unitFamilyAsRegexpString()));
+      }
+    };
+  }
 }

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/JvmFlag.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/JvmFlag.java
@@ -127,6 +127,11 @@ public enum JvmFlag {
   private final Formatter formatter;
 
   /**
+   * The {@link Validator} flyweight.
+   */
+  private final Validator validator;
+
+  /**
    * The minimum acceptable value for the flag.
    */
   private final Long floorValue;
@@ -173,7 +178,8 @@ public enum JvmFlag {
     this.name = Preconditions.checkNotNull(name, "name may not be null.");
     this.hotSpotFlagType = Preconditions.checkNotNull(hotSpotFlagType, "hotSpotFlagType may not be null.");
 
-    formatter = Formatters.BOOLEAN_FORMATTER;
+    formatter = Formatters.BOOLEAN;
+    validator = Validators.BOOLEAN;
     floorValue = 0L;
     ceilingValue = 1L;
     stepSize = 1L;
@@ -202,7 +208,8 @@ public enum JvmFlag {
     this.dataSize = Preconditions.checkNotNull(dataSize, "dataSize may not be null.");
     this.valueSeparator = Preconditions.checkNotNull(valueSeparator, "valueSeparator may not be null.");
 
-    formatter = Formatters.INTEGER_FORMATTER;
+    formatter = Formatters.INTEGER;
+    validator = Validators.INTEGER;
     acceptableValueRange = Range.closed(minimum, maximum);
   }
 
@@ -212,10 +219,6 @@ public enum JvmFlag {
 
   HotSpotFlagType getHotSpotFlagType() {
     return hotSpotFlagType;
-  }
-
-  Formatter getFormatter() {
-    return formatter;
   }
 
   public long getMinimum() {
@@ -249,7 +252,7 @@ public enum JvmFlag {
    * @return The String representation.
    */
   public String asArgumentString(final Long value) {
-    return getFormatter().asArgumentString(this, value);
+    return formatter.asArgumentString(this, value);
   }
 
   /**
@@ -258,16 +261,7 @@ public enum JvmFlag {
    * @return The String representation.
    */
   public String asRegularExpressionString() {
-    return getFormatter().asRegularExpressionString(this);
-  }
-
-  /**
-   * Provide a representation of the allowed values as String.
-   *
-   * @return The String representation.
-   */
-  public String asAcceptableValuesString() {
-    return getFormatter().asAcceptableValuesString(this);
+    return formatter.asRegularExpressionString(this);
   }
 
   /**
@@ -277,7 +271,7 @@ public enum JvmFlag {
    * @throws IllegalArgumentException In case of a bad argument.
    */
   public void validate(final Long proposedValue) throws IllegalArgumentException {
-    getFormatter().validate(this, proposedValue);
+    validator.validate(this, proposedValue);
   }
 
   /**

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Validator.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Validator.java
@@ -1,0 +1,15 @@
+package org.arbeitspferde.groningen.experimentdb.jvmflags;
+
+interface Validator {
+  /**
+   * Verify that the proposed value is acceptable.
+   *
+   * Implementors should include information in the thrown exception about why
+   * proposedValue is unacceptable.
+   *
+   * @param cla The argument for which this formatter is used.
+   * @param proposedValue The value to verify.
+   * @throws IllegalArgumentException if proposedValue is unacceptable.
+   */
+  void validate(final JvmFlag cla, final long proposedValue) throws IllegalArgumentException;
+}

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Validators.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Validators.java
@@ -15,7 +15,7 @@ class Validators {
       Preconditions.checkArgument(
           cla.getAcceptableValueRange().contains(proposedValue),
           "The flag %s with range %s cannot contain proposed value %s.",
-          cla.getName(), cla.getAcceptableValueRange(),
+          cla, cla.getAcceptableValueRange(),
           proposedValue);
       }
   };

--- a/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Validators.java
+++ b/src/main/java/org/arbeitspferde/groningen/experimentdb/jvmflags/Validators.java
@@ -1,0 +1,34 @@
+package org.arbeitspferde.groningen.experimentdb.jvmflags;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
+
+class Validators {
+  static final Validator INTEGER = new Validator() {
+    private final Range<Long> inherentAcceptableValues = Range.closed((long) Integer.MIN_VALUE,
+        (long) Integer.MAX_VALUE);
+
+    @Override
+    public void validate(final JvmFlag cla, final long proposedValue) throws IllegalArgumentException {
+      Preconditions.checkNotNull(cla, "cla may not be null.");
+      Preconditions.checkArgument(inherentAcceptableValues.contains(proposedValue));
+      Preconditions.checkArgument(
+          cla.getAcceptableValueRange().contains(proposedValue),
+          "The flag %s with range %s cannot contain proposed value %s.",
+          cla.getName(), cla.getAcceptableValueRange(),
+          proposedValue);
+      }
+  };
+
+  static final Validator BOOLEAN = new Validator() {
+    private final Range<Long> inherentAcceptableValues = Range.closed(0L, 1L);
+
+    @Override
+    public void validate(final JvmFlag cla, final long proposedValue)
+        throws IllegalArgumentException {
+      Preconditions.checkNotNull(cla, "cla may not be null.");
+      Preconditions.checkArgument(inherentAcceptableValues.contains(proposedValue));
+    }
+
+  };
+}

--- a/src/main/java/org/arbeitspferde/groningen/open/OpenModule.java
+++ b/src/main/java/org/arbeitspferde/groningen/open/OpenModule.java
@@ -72,7 +72,7 @@ public class OpenModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    log.info("Binding open injectables.");
+    log.finest("Binding open injectables.");
 
     MapBinder<String, Datastore> datastoreBinder = MapBinder.newMapBinder(binder(), String.class,
         Datastore.class);

--- a/src/test/java/org/arbeitspferde/groningen/AllTests.java
+++ b/src/test/java/org/arbeitspferde/groningen/AllTests.java
@@ -42,6 +42,7 @@ import org.arbeitspferde.groningen.experimentdb.jvmflags.FormattersTest;
 import org.arbeitspferde.groningen.experimentdb.jvmflags.HotSpotFlagTypeTest;
 import org.arbeitspferde.groningen.experimentdb.jvmflags.JvmFlagSetTest;
 import org.arbeitspferde.groningen.experimentdb.jvmflags.JvmFlagTest;
+import org.arbeitspferde.groningen.experimentdb.jvmflags.ValidatorsTest;
 import org.arbeitspferde.groningen.experimentdb.jvmflags.ValueSeparatorTest;
 import org.arbeitspferde.groningen.generator.GeneratorTest;
 import org.arbeitspferde.groningen.hypothesizer.HypothesizerTest;
@@ -108,6 +109,7 @@ public class AllTests extends TestSuite{
     suite.addTestSuite(JvmFlagSetTest.class);
     suite.addTestSuite(JvmFlagTest.class);
     suite.addTestSuite(ValueSeparatorTest.class);
+    suite.addTestSuite(ValidatorsTest.class);
 
     // org.arbeitspferde.groningen.generator tests
     suite.addTestSuite(GeneratorTest.class);

--- a/src/test/java/org/arbeitspferde/groningen/experimentdb/CommandLineTest.java
+++ b/src/test/java/org/arbeitspferde/groningen/experimentdb/CommandLineTest.java
@@ -194,7 +194,7 @@ public class CommandLineTest extends TestCase {
   public void testToArgumentStringSanity() {
     final String result = p.toArgumentString();
 
-    assertEquals("-Xmx1024m -Xms1024m -XX:NewSize=8m -XX:MaxNewSize=8m -XX:SurvivorRatio=52 "
+    assertEquals("-Xms1024m -Xmx1024m -XX:NewSize=8m -XX:MaxNewSize=8m -XX:SurvivorRatio=52 "
         + "-XX:SoftRefLRUPolicyMSPerMB=2000 -XX:+UseConcMarkSweepGC "
         + "-XX:CMSInitiatingOccupancyFraction=3 -XX:-UseCMSInitiatingOccupancyOnly", result);
   }
@@ -364,9 +364,8 @@ public class CommandLineTest extends TestCase {
   }
 
   public void testRegularExpressionsMatch_MaxNewSize() {
-    assertMatchesNever("-XX:MaxNewSize=1");
-    assertMatchesNever("-XX:MaxNewSize=11");
-
+    assertMatchesOnce("-XX:MaxNewSize=1");
+    assertMatchesOnce("-XX:MaxNewSize=11");
     assertMatchesOnce("-XX:MaxNewSize=1k");
     assertMatchesOnce("-XX:MaxNewSize=1m");
     assertMatchesOnce("-XX:MaxNewSize=1g");
@@ -406,9 +405,8 @@ public class CommandLineTest extends TestCase {
   }
 
   public void testRegularExpressionsMatch_NewSize() {
-    assertMatchesNever("-XX:NewSize=1");
-    assertMatchesNever("-XX:NewSize=11");
-
+    assertMatchesOnce("-XX:NewSize=1");
+    assertMatchesOnce("-XX:NewSize=11");
     assertMatchesOnce("-XX:NewSize=1k");
     assertMatchesOnce("-XX:NewSize=1m");
     assertMatchesOnce("-XX:NewSize=1g");

--- a/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/DataSizeTest.java
+++ b/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/DataSizeTest.java
@@ -26,10 +26,6 @@ public class DataSizeTest extends TestCase {
     assertEquals("", DataSize.NONE.getSuffix());
   }
 
-  public void test_getSuffix_BYTE() {
-    assertEquals("b", DataSize.BYTE.getSuffix());
-  }
-
   public void test_getSuffix_KILO() {
     assertEquals("k", DataSize.KILO.getSuffix());
   }
@@ -46,19 +42,15 @@ public class DataSizeTest extends TestCase {
     assertEquals("", DataSize.NONE.unitFamilyAsRegexpString());
   }
 
-  public void test_unitFamilyAsRegexpString_BYTE() {
-    assertEquals("[bBkKmMgG]", DataSize.BYTE.unitFamilyAsRegexpString());
-  }
-
   public void test_unitFamilyAsRegexpString_KILO() {
-    assertEquals("[bBkKmMgG]", DataSize.KILO.unitFamilyAsRegexpString());
+    assertEquals("[kKmMgG]?", DataSize.KILO.unitFamilyAsRegexpString());
   }
 
   public void test_unitFamilyAsRegexpString_MEGA() {
-    assertEquals("[bBkKmMgG]", DataSize.MEGA.unitFamilyAsRegexpString());
+    assertEquals("[kKmMgG]?", DataSize.MEGA.unitFamilyAsRegexpString());
   }
 
   public void test_unitFamilyAsRegexpString_GIGA() {
-    assertEquals("[bBkKmMgG]", DataSize.GIGA.unitFamilyAsRegexpString());
+    assertEquals("[kKmMgG]?", DataSize.GIGA.unitFamilyAsRegexpString());
   }
 }

--- a/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/FormattersTest.java
+++ b/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/FormattersTest.java
@@ -15,8 +15,13 @@
 
 package org.arbeitspferde.groningen.experimentdb.jvmflags;
 
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
 
 import junit.framework.TestCase;
+import org.hamcrest.Description;
+import org.junit.internal.matchers.TypeSafeMatcher;
 
 /**
  * Tests for {@link Formatters}.
@@ -31,79 +36,30 @@ public class FormattersTest extends TestCase {
   }
 
   public void test_INTEGER_FORMATTER_asArgumentString_AdaptiveSizeDecrementScaleFactor() {
-    final String actual = Formatters.INTEGER.asArgumentString(
+    final ImmutableList<String> actual = Formatters.INTEGER.asArgumentString(
         JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 2L);
 
-    assertEquals("-XX:AdaptiveSizeDecrementScaleFactor=2", actual);
+    assertThat(actual, matches("-XX:AdaptiveSizeDecrementScaleFactor=2"));
   }
 
   public void test_INTEGER_FORMATTER_asArgumentString_MaxNewSize() {
-    final String actual = Formatters.INTEGER.asArgumentString(
+    final ImmutableList<String> actual = Formatters.INTEGER.asArgumentString(
         JvmFlag.MAX_NEW_SIZE, 3L);
 
-    assertEquals("-XX:MaxNewSize=3m", actual);
+    assertThat(actual, matches("-XX:MaxNewSize=3m"));
   }
 
   public void test_INTEGER_FORMATTER_asRegularExpression_AdaptiveSizeDecrementFactor() {
-    final String actual = Formatters.INTEGER.asRegularExpressionString(
+    final ImmutableList<String> actual = Formatters.INTEGER.asRegularExpressionString(
         JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR);
 
-    assertEquals("-XX:AdaptiveSizeDecrementScaleFactor=\\d+\\b", actual);
+    assertThat(actual, matches("-XX:AdaptiveSizeDecrementScaleFactor=\\d+\\b"));
   }
 
   public void test_INTEGER_FORMATTER_asRegularExpression_MaxNewSize() {
-    final String actual = Formatters.INTEGER.asRegularExpressionString(
+    final ImmutableList<String> actual = Formatters.INTEGER.asRegularExpressionString(
         JvmFlag.MAX_NEW_SIZE);
-
-    assertEquals("-XX:MaxNewSize=\\d+[bBkKmMgG]\\b", actual);
-  }
-
-  public void test_INTEGER_FORMATTER_asAcceptableValuesString_AdaptiveSizeDecrementFactor() {
-    final String actual = Formatters.INTEGER.asAcceptableValuesString(
-        JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR);
-
-    assertEquals("[0\u2025100]", actual);
-  }
-
-  public void test_INTEGER_FORMATTER_asAcceptableValuesString_MaxNewSize() {
-    final String actual = Formatters.INTEGER.asAcceptableValuesString(
-        JvmFlag.MAX_NEW_SIZE);
-
-    assertEquals("[0\u202532768]", actual);
-  }
-
-  public void test_INTEGER_FORMATTER_validate_AdaptiveSizeDecrementFactor_InvalidValues() {
-    try {
-      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, -1L);
-      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR disallows -1.");
-    } catch (final IllegalArgumentException e) {
-    }
-
-    try {
-      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 101L);
-      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR disallows 101.");
-    } catch (final IllegalArgumentException e) {
-    }
-  }
-
-  public void test_INTEGER_FORMATTER_validate_AdaptiveSizeDecrementFactor_ValidValues() {
-    try {
-      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 1L);
-    } catch (final IllegalArgumentException e) {
-      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR allows 1.");
-    }
-
-    try {
-      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 50L);
-    } catch (final IllegalArgumentException e) {
-      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR allows 50");
-    }
-
-    try {
-      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 100L);
-    } catch (final IllegalArgumentException e) {
-      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR allows 100");
-    }
+    assertThat(actual, matches("-XX:MaxNewSize=\\d+[kKmMgG]?\\b"));
   }
 
   public void test_BOOLEAN_FORMATTER_asArgumentString_DisallowsNullArguments() {
@@ -115,58 +71,38 @@ public class FormattersTest extends TestCase {
   }
 
   public void test_BOOLEAN_FORMATTER_asArgumentString_CMSIncrementalMode_true() {
-    final String actual = Formatters.BOOLEAN.asArgumentString(
+    final ImmutableList<String> actual = Formatters.BOOLEAN.asArgumentString(
       JvmFlag.CMS_INCREMENTAL_MODE, 1L);
 
-    assertEquals("-XX:+CMSIncrementalMode", actual);
+    assertThat(actual, matches("-XX:+CMSIncrementalMode"));
   }
 
   public void test_BOOLEAN_FORMATTER_asArgumentString_CMSIncrementalMode_false() {
-    final String actual = Formatters.BOOLEAN.asArgumentString(
+    final ImmutableList<String> actual = Formatters.BOOLEAN.asArgumentString(
       JvmFlag.CMS_INCREMENTAL_MODE, 0L);
 
-    assertEquals("-XX:-CMSIncrementalMode", actual);
+    assertThat(actual, matches("-XX:-CMSIncrementalMode"));
   }
 
   public void test_BOOLEAN_FORMATTER_asRegularExpression_CMSIncrementalMode() {
-    final String actual = Formatters.BOOLEAN.asRegularExpressionString(
+    final ImmutableList<String> actual = Formatters.BOOLEAN.asRegularExpressionString(
       JvmFlag.CMS_INCREMENTAL_MODE);
 
-    assertEquals("-XX:[+-]CMSIncrementalMode", actual);
+    assertThat(actual, matches("-XX:[+-]CMSIncrementalMode"));
   }
 
-  public void test_BOOLEAN_FORMATTER_asAcceptableValuesString_CMSIncrementalMode() {
-    final String actual = Formatters.BOOLEAN.asAcceptableValuesString(
-      JvmFlag.CMS_INCREMENTAL_MODE);
+  private static TypeSafeMatcher<ImmutableList<String>> matches(final String ...expected) {
+    return new TypeSafeMatcher<ImmutableList<String>>() {
+      @Override
+      public boolean matchesSafely(ImmutableList<String> item) {
+        return ImmutableList.copyOf(expected).equals(item);
+      }
 
-    assertEquals("{0 (false), 1 (true)}", actual);
-  }
-
-  public void test_BOOLEAN_FORMATTER_validate_CMSIncrementalMode_InvalidValues() {
-    try {
-      Formatters.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, -1L);
-      fail("JvmFlags.CMS_INCREMENTAL_MODE disallows -1.");
-    } catch (final IllegalArgumentException e) {
-    }
-
-    try {
-      Formatters.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, 2L);
-      fail("JvmFlags.CMS_INCREMENTAL_MODE disallows 2.");
-    } catch (final IllegalArgumentException e) {
-    }
-  }
-
-  public void test_BOOLEAN_FORMATTER_validate_CMSIncrementalMode_ValidValues() {
-    try {
-      Formatters.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, 0L);
-    } catch (final IllegalArgumentException e) {
-      fail("JvmFlags.CMS_INCREMENTAL_MODE allows 0.");
-    }
-
-    try {
-      Formatters.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, 1L);
-    } catch (final IllegalArgumentException e) {
-      fail("JvmFlags.CMS_INCREMENTAL_MODE allows 1.");
-    }
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("expected ")
+            .appendValue(expected);
+      }
+    };
   }
 }

--- a/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/FormattersTest.java
+++ b/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/FormattersTest.java
@@ -24,49 +24,49 @@ import junit.framework.TestCase;
 public class FormattersTest extends TestCase {
   public void test_INTEGER_FORMATTER_asArgumentString_DisallowsNullArguments() {
     try {
-      Formatters.INTEGER_FORMATTER.asArgumentString(null, 0L);
-      fail("Formatters.INTEGER_FORMATTER should disallow null arguments.");
+      Formatters.INTEGER.asArgumentString(null, 0L);
+      fail("Formatters.INTEGER should disallow null arguments.");
     } catch (final NullPointerException e) {
     }
   }
 
   public void test_INTEGER_FORMATTER_asArgumentString_AdaptiveSizeDecrementScaleFactor() {
-    final String actual = Formatters.INTEGER_FORMATTER.asArgumentString(
+    final String actual = Formatters.INTEGER.asArgumentString(
         JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 2L);
 
     assertEquals("-XX:AdaptiveSizeDecrementScaleFactor=2", actual);
   }
 
   public void test_INTEGER_FORMATTER_asArgumentString_MaxNewSize() {
-    final String actual = Formatters.INTEGER_FORMATTER.asArgumentString(
+    final String actual = Formatters.INTEGER.asArgumentString(
         JvmFlag.MAX_NEW_SIZE, 3L);
 
     assertEquals("-XX:MaxNewSize=3m", actual);
   }
 
   public void test_INTEGER_FORMATTER_asRegularExpression_AdaptiveSizeDecrementFactor() {
-    final String actual = Formatters.INTEGER_FORMATTER.asRegularExpressionString(
+    final String actual = Formatters.INTEGER.asRegularExpressionString(
         JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR);
 
     assertEquals("-XX:AdaptiveSizeDecrementScaleFactor=\\d+\\b", actual);
   }
 
   public void test_INTEGER_FORMATTER_asRegularExpression_MaxNewSize() {
-    final String actual = Formatters.INTEGER_FORMATTER.asRegularExpressionString(
+    final String actual = Formatters.INTEGER.asRegularExpressionString(
         JvmFlag.MAX_NEW_SIZE);
 
     assertEquals("-XX:MaxNewSize=\\d+[bBkKmMgG]\\b", actual);
   }
 
   public void test_INTEGER_FORMATTER_asAcceptableValuesString_AdaptiveSizeDecrementFactor() {
-    final String actual = Formatters.INTEGER_FORMATTER.asAcceptableValuesString(
+    final String actual = Formatters.INTEGER.asAcceptableValuesString(
         JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR);
 
     assertEquals("[0\u2025100]", actual);
   }
 
   public void test_INTEGER_FORMATTER_asAcceptableValuesString_MaxNewSize() {
-    final String actual = Formatters.INTEGER_FORMATTER.asAcceptableValuesString(
+    final String actual = Formatters.INTEGER.asAcceptableValuesString(
         JvmFlag.MAX_NEW_SIZE);
 
     assertEquals("[0\u202532768]", actual);
@@ -74,13 +74,13 @@ public class FormattersTest extends TestCase {
 
   public void test_INTEGER_FORMATTER_validate_AdaptiveSizeDecrementFactor_InvalidValues() {
     try {
-      Formatters.INTEGER_FORMATTER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, -1L);
+      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, -1L);
       fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR disallows -1.");
     } catch (final IllegalArgumentException e) {
     }
 
     try {
-      Formatters.INTEGER_FORMATTER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 101L);
+      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 101L);
       fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR disallows 101.");
     } catch (final IllegalArgumentException e) {
     }
@@ -88,19 +88,19 @@ public class FormattersTest extends TestCase {
 
   public void test_INTEGER_FORMATTER_validate_AdaptiveSizeDecrementFactor_ValidValues() {
     try {
-      Formatters.INTEGER_FORMATTER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 1L);
+      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 1L);
     } catch (final IllegalArgumentException e) {
       fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR allows 1.");
     }
 
     try {
-      Formatters.INTEGER_FORMATTER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 50L);
+      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 50L);
     } catch (final IllegalArgumentException e) {
       fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR allows 50");
     }
 
     try {
-      Formatters.INTEGER_FORMATTER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 100L);
+      Formatters.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 100L);
     } catch (final IllegalArgumentException e) {
       fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR allows 100");
     }
@@ -108,35 +108,35 @@ public class FormattersTest extends TestCase {
 
   public void test_BOOLEAN_FORMATTER_asArgumentString_DisallowsNullArguments() {
     try {
-      Formatters.BOOLEAN_FORMATTER.asArgumentString(null, 0L);
-      fail("Formatters.BOOLEAN_FORMATTER should disallow null arguments.");
+      Formatters.BOOLEAN.asArgumentString(null, 0L);
+      fail("Formatters.BOOLEAN should disallow null arguments.");
     } catch (final NullPointerException e) {
     }
   }
 
   public void test_BOOLEAN_FORMATTER_asArgumentString_CMSIncrementalMode_true() {
-    final String actual = Formatters.BOOLEAN_FORMATTER.asArgumentString(
+    final String actual = Formatters.BOOLEAN.asArgumentString(
       JvmFlag.CMS_INCREMENTAL_MODE, 1L);
 
     assertEquals("-XX:+CMSIncrementalMode", actual);
   }
 
   public void test_BOOLEAN_FORMATTER_asArgumentString_CMSIncrementalMode_false() {
-    final String actual = Formatters.BOOLEAN_FORMATTER.asArgumentString(
+    final String actual = Formatters.BOOLEAN.asArgumentString(
       JvmFlag.CMS_INCREMENTAL_MODE, 0L);
 
     assertEquals("-XX:-CMSIncrementalMode", actual);
   }
 
   public void test_BOOLEAN_FORMATTER_asRegularExpression_CMSIncrementalMode() {
-    final String actual = Formatters.BOOLEAN_FORMATTER.asRegularExpressionString(
+    final String actual = Formatters.BOOLEAN.asRegularExpressionString(
       JvmFlag.CMS_INCREMENTAL_MODE);
 
     assertEquals("-XX:[+-]CMSIncrementalMode", actual);
   }
 
   public void test_BOOLEAN_FORMATTER_asAcceptableValuesString_CMSIncrementalMode() {
-    final String actual = Formatters.BOOLEAN_FORMATTER.asAcceptableValuesString(
+    final String actual = Formatters.BOOLEAN.asAcceptableValuesString(
       JvmFlag.CMS_INCREMENTAL_MODE);
 
     assertEquals("{0 (false), 1 (true)}", actual);
@@ -144,13 +144,13 @@ public class FormattersTest extends TestCase {
 
   public void test_BOOLEAN_FORMATTER_validate_CMSIncrementalMode_InvalidValues() {
     try {
-      Formatters.BOOLEAN_FORMATTER.validate(JvmFlag.CMS_INCREMENTAL_MODE, -1L);
+      Formatters.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, -1L);
       fail("JvmFlags.CMS_INCREMENTAL_MODE disallows -1.");
     } catch (final IllegalArgumentException e) {
     }
 
     try {
-      Formatters.BOOLEAN_FORMATTER.validate(JvmFlag.CMS_INCREMENTAL_MODE, 2L);
+      Formatters.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, 2L);
       fail("JvmFlags.CMS_INCREMENTAL_MODE disallows 2.");
     } catch (final IllegalArgumentException e) {
     }
@@ -158,13 +158,13 @@ public class FormattersTest extends TestCase {
 
   public void test_BOOLEAN_FORMATTER_validate_CMSIncrementalMode_ValidValues() {
     try {
-      Formatters.BOOLEAN_FORMATTER.validate(JvmFlag.CMS_INCREMENTAL_MODE, 0L);
+      Formatters.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, 0L);
     } catch (final IllegalArgumentException e) {
       fail("JvmFlags.CMS_INCREMENTAL_MODE allows 0.");
     }
 
     try {
-      Formatters.BOOLEAN_FORMATTER.validate(JvmFlag.CMS_INCREMENTAL_MODE, 1L);
+      Formatters.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, 1L);
     } catch (final IllegalArgumentException e) {
       fail("JvmFlags.CMS_INCREMENTAL_MODE allows 1.");
     }

--- a/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/JvmFlagTest.java
+++ b/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/JvmFlagTest.java
@@ -16,6 +16,8 @@
 package org.arbeitspferde.groningen.experimentdb.jvmflags;
 
 
+import com.google.common.collect.ImmutableList;
+
 import junit.framework.TestCase;
 
 import java.util.List;
@@ -25,15 +27,15 @@ import java.util.List;
  */
 public class JvmFlagTest extends TestCase {
   public void test_asArgumentString_MAX_NEW_SIZE() {
-    final String actual = JvmFlag.MAX_NEW_SIZE.asArgumentString(1L);
+    final ImmutableList<String> actual = JvmFlag.MAX_NEW_SIZE.asArgumentString(1L);
 
-    assertEquals("-XX:MaxNewSize=1m", actual);
+    assertEquals(ImmutableList.of("-XX:MaxNewSize=1m"), actual);
   }
 
   public void test_asRegularExpressionString_MAX_NEW_SIZE() {
-    final String actual = JvmFlag.MAX_NEW_SIZE.asRegularExpressionString();
+    final ImmutableList<String> actual = JvmFlag.MAX_NEW_SIZE.asRegularExpressionString();
 
-    assertEquals("-XX:MaxNewSize=\\d+[bBkKmMgG]\\b", actual);
+    assertEquals(ImmutableList.of("-XX:MaxNewSize=\\d+[kKmMgG]?\\b"), actual);
   }
 
   public void test_validate_MAX_NEW_SIZE_InvalidValues() {

--- a/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/JvmFlagTest.java
+++ b/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/JvmFlagTest.java
@@ -70,10 +70,4 @@ public class JvmFlagTest extends TestCase {
     assertEquals(JvmFlag.USE_PARALLEL_OLD_GC, JvmFlag.getGcModeArgument(GcMode.PARALLEL_OLD));
     assertEquals(JvmFlag.USE_SERIAL_GC, JvmFlag.getGcModeArgument(GcMode.SERIAL));
   }
-
-  public void test_asAcceptableValuesString_MAX_NEW_SIZE() {
-    final String actual = JvmFlag.MAX_NEW_SIZE.asAcceptableValuesString();
-
-    assertEquals("[0\u202532768]", actual);
-  }
 }

--- a/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/ValidatorsTest.java
+++ b/src/test/java/org/arbeitspferde/groningen/experimentdb/jvmflags/ValidatorsTest.java
@@ -1,0 +1,70 @@
+package org.arbeitspferde.groningen.experimentdb.jvmflags;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link Validators}.
+ */
+public class ValidatorsTest extends TestCase {
+  public void test_INTEGER_FORMATTER_validate_AdaptiveSizeDecrementFactor_InvalidValues() {
+    try {
+      Validators.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, -1L);
+      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR disallows -1.");
+    } catch (final IllegalArgumentException e) {
+    }
+
+    try {
+      Validators.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 101L);
+      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR disallows 101.");
+    } catch (final IllegalArgumentException e) {
+    }
+  }
+
+  public void test_INTEGER_FORMATTER_validate_AdaptiveSizeDecrementFactor_ValidValues() {
+    try {
+      Validators.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 1L);
+    } catch (final IllegalArgumentException e) {
+      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR allows 1.");
+    }
+
+    try {
+      Validators.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 50L);
+    } catch (final IllegalArgumentException e) {
+      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR allows 50");
+    }
+
+    try {
+      Validators.INTEGER.validate(JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR, 100L);
+    } catch (final IllegalArgumentException e) {
+      fail("JvmFlag.ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR allows 100");
+    }
+  }
+
+  public void test_BOOLEAN_FORMATTER_validate_CMSIncrementalMode_InvalidValues() {
+    try {
+      Validators.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, -1L);
+      fail("JvmFlags.CMS_INCREMENTAL_MODE disallows -1.");
+    } catch (final IllegalArgumentException e) {
+    }
+
+    try {
+      Validators.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, 2L);
+      fail("JvmFlags.CMS_INCREMENTAL_MODE disallows 2.");
+    } catch (final IllegalArgumentException e) {
+    }
+  }
+
+  public void test_BOOLEAN_FORMATTER_validate_CMSIncrementalMode_ValidValues() {
+    try {
+      Validators.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, 0L);
+    } catch (final IllegalArgumentException e) {
+      fail("JvmFlags.CMS_INCREMENTAL_MODE allows 0.");
+    }
+
+    try {
+      Validators.BOOLEAN.validate(JvmFlag.CMS_INCREMENTAL_MODE, 1L);
+    } catch (final IllegalArgumentException e) {
+      fail("JvmFlags.CMS_INCREMENTAL_MODE allows 1.");
+    }
+  }
+}


### PR DESCRIPTION
Two independent changes: Emit formatted flags as lists, and extract validation to its own domain type.

To better manage the overhaul of how the garbage collection strategy selection and such is handled, we need to simplify the flag representation even further.  Without doing this, we make a bigger mess for ourselves.  The simplifications allow us to start dropping the one-off treatment of argument formation in `CommandLine` and rely on `JvmFlag` for a naive search space.  This is to say, if we want to support semantically incorrect search space generation, then we need to enable to code to do so easily.

@etheon, this will need some careful consideration.
